### PR TITLE
docs: adição da gravação do módulo 1

### DIFF
--- a/docs/gravacoes/gravacao-video-modulo1.md
+++ b/docs/gravacoes/gravacao-video-modulo1.md
@@ -1,0 +1,58 @@
+# Documento de Gravação - Entrega do Módulo 1
+
+## Introdução
+Este documento registra a gravação do vídeo de entrega do Módulo 1 do projeto Star Wars, onde o grupo apresentou a documentação completa do projeto, incluindo o Modelo Entidade-Relacionamento (MER), Modelo Relacional e Dicionário de Dados.
+
+## Detalhes da Gravação
+
+### Data da Gravação
+02/05/2025
+
+### Participantes
+- Artur Mendonça 
+- Amanda 
+- Eduardo 
+
+### Conteúdo Apresentado
+1. **Documentação do Projeto**
+   - Apresentação geral do projeto
+   - Objetivos e escopo
+   - Requisitos funcionais e não funcionais
+
+2. **Modelo Entidade-Relacionamento (MER)**
+   - Explicação das entidades
+   - Relacionamentos entre entidades
+   - Cardinalidades
+   - Atributos e suas características
+
+3. **Modelo Relacional**
+   - Conversão do MER para o modelo relacional
+   - Tabelas e suas estruturas
+   - Chaves primárias e estrangeiras
+   - Normalização
+
+4. **Dicionário de Dados**
+   - Descrição detalhada de cada entidade
+   - Definição dos atributos
+   - Tipos de dados
+   - Restrições e validações
+
+## Vídeo Gravado
+
+A apresentação foi realizada e gravada por meio da plataforma Google Meet. O vídeo está disponível no seguinte link:
+
+🔗 [Acessar gravação da apresentação](https://youtu.be/E6S3FcUH1a0)
+
+> **Nota:** Caso o link não esteja acessível, entre em contato com o responsável do grupo para solicitar o vídeo.
+
+## Referências Bibliográficas
+1. GOOGLE. *Google Meet*. Disponível em: [https://meet.google.com/](https://meet.google.com/). Acesso em: 2 maio 2025.
+
+## Observações Finais
+Este documento serve como registro oficial da gravação do vídeo de entrega do Módulo 1, garantindo a transparência e organização do processo de desenvolvimento do projeto.
+
+## Histórico de Versões
+
+| Versão | Data       | Modificações                                         | Autor(es)                                                                                      | Revisor(es)                                   |
+|--------|------------|------------------------------------------------------|------------------------------------------------------------------------------------------------|-----------------------------------------------|
+| 1.0    | 02/05/2025 | Criação do documento de modelo entidade-relacionamento | [Artur Mendonça](https://github.com/ArtyMend07), [Amanda Abreu](https://github.com/Amandaaaaabreu), [Eduardo Morais](https://github.com/Edumorais08) | [Amanda Abreu](https://github.com/Amandaaaaabreu) |


### PR DESCRIPTION
## 📌 Descrição

Este PR adiciona o documento de gravação da entrega do Módulo 1 do projeto Star Wars, contendo informações sobre o vídeo de apresentação, participantes, conteúdo abordado, referências e histórico de versões.

## ✅ Tipo de mudança

- [x] Documentação
- [ ] Bug fix
- [ ] Nova feature
- [ ] Refatoração
- [ ] Testes
- [ ] Outra (descreva):

## 🧪 Como testar

1. Acesse o arquivo `documento-gravacao-modulo1.md`.
2. Verifique se todas as seções estão preenchidas corretamente.
3. Confirme se o link do vídeo foi inserido (caso disponível).
4. Valide os nomes e perfis dos autores no histórico de versões.

## 📋 Checklist

- [x] O código segue o padrão do projeto
- [x] Testei localmente (leitura e formatação)
- [x] Atualizei a documentação
- [x] Não quebrei nada que estava funcionando
