### PR TITLE
docs: Adiciona sprint 1 no projeto

### DIFF
--- a/docs/sprint-01.md
+++ b/docs/sprint-01.md
@@ -1,0 +1,57 @@
+# Relatório da Sprint 
+
+**Período da Sprint:** [18/05/2025] até [09/06/2025]  
+**Duração:** 3 semanas  
+**Data de Finalização:** 09/06/2025  
+
+---
+
+## Objetivos da Sprint
+
+Nesta segunda sprint, focamos na finalização da modelagem do banco de dados e iniciamos a implementação física para o **Módulo 2** do projeto.
+
+As atividades planejadas e executadas foram:
+
+- Aplicação de regras de integridade e integridade referencial ao modelo.
+- Normalização do modelo até a 4FN (Forma Normal).
+- Início da criação das tabelas e constraints no SGBD PostgreSQL.
+- Preparação para inserção de dados iniciais.
+- Revisão e validação do modelo relacional com base nos requisitos do projeto.
+
+---
+
+## Entregas Realizadas
+
+- ✅ Modelo Relacional com regras de integridade aplicadas
+  - **Responsável:** Eduardo Morais, Artur Mendonça
+- ✅ Normalização do modelo até a 4FN
+  - **Responsável:** Amanda Abreu, Filipe Bressanelli
+- ✅ Scripts SQL iniciais para criação das tabelas (DDL)
+  - **Responsável:** Artur Mendonça, Renan Paris
+- ✅ Documentação das constraints e regras de negócio
+  - **Responsável:** Renan Paris
+
+
+## Observações
+
+- A normalização do modelo exigiu algumas alterações no diagrama entidade-relacionamento original, que foram devidamente documentadas.
+- Os scripts SQL foram desenvolvidos para o PostgreSQL, conforme definido na metodologia do projeto.
+- Foi iniciado o planejamento para a próxima sprint, que focará na inserção de dados e desenvolvimento das primeiras consultas SQL.
+
+## Participantes
+
+<table>
+    <tr>
+    <td align="center"><a href="https://github.com/ArtyMend07"><img src="https://avatars.githubusercontent.com/u/121322804?v=4" width="200px;" alt=""/><br/><sub><b>Artur Mendonça</b></sub></a><br/>
+    <td align="center"><a href="https://github.com/Edumorais08"><img src="https://avatars.githubusercontent.com/u/139409504?v=4" width="200px;" alt=""/><br /><sub><b>Eduardo Morais</b></sub></a><br />
+    <td align="center"><a href="https://github.com/fbressa"><img src="https://avatars.githubusercontent.com/u/123025849?v=4" width="200px;" alt=""/><br /><sub><b>Filipe Bressanelli</b></sub></a><br />
+    <td align="center"><a href="https://github.com/Amandaaaaabreu"><img src="https://avatars.githubusercontent.com/u/103958998?v=4" width="200px;" alt=""/><br /><sub><b>Amanda Abreu</b></sub></a><br />
+    <td align="center"><a href="https://github.com/renanpariiz"><img src="https://avatars.githubusercontent.com/u/101299192?v=4" width="200px;" alt=""/><br /><sub><b>Renan Pariz</b></sub></a><br />
+    </tr>
+</table>
+
+## Histórico de Versões
+
+| Versão | Data       | Modificações                                      | Autor(es)     | Revisor(es) |
+|--------|------------|---------------------------------------------------|---------------|-------------|
+| 1.0    | 18/05/2025 | Adição da sprint 1 do projeto  | [Artur Mendonça](https://github.com/ArtyMend07) |  [Eduardo Morais](https://github.com/Edumorais08) | 


### PR DESCRIPTION
## 📌 Descrição

Adição do documento de sprint-01 cobrindo o período de 18/05/2025 a 09/06/2025, detalhando as atividades realizadas na segunda sprint do projeto Star Wars, com foco na finalização da modelagem e início da implementação em SQL.

## ✅ Tipo de mudança

- [ ] Bug fix
- [ ] Nova feature
- [ ] Refatoração
- [x] Documentação
- [ ] Testes
- [ ] Outra (descreva):

## 🧪 Como testar

Verificar se o documento está corretamente formatado e se o conteúdo está alinhado com o cronograma e metodologia do projeto. O arquivo pode ser visualizado em `/docs/sprint-01.md`.

## 🔗 Issue relacionada

Closes #25 (Documentação da Sprint 01)

## 📋 Checklist

- [x] O código segue o padrão do projeto
- [x] Testei localmente a visualização do documento
- [x] Atualizei a documentação conforme o template existente
- [x] O conteúdo está alinhado com cronograma e metodologia
- [x] Todas as contribuições dos membros foram documentadas